### PR TITLE
bug fix: convert zero-sized tensor to numpy array

### DIFF
--- a/pynuml/io/out.py
+++ b/pynuml/io/out.py
@@ -69,6 +69,7 @@ class H5Out:
                 if val.nelement() == 0: # save tensor with zero-sized dimension as a scalar 0
                     # HDF5 compound data type does not allow zero-size dimension
                     # ValueError: Zero-sized dimension specified (zero-sized dimension specified)
+                    val = val.numpy()  # convert a tensor to numpy
                     data = data + (0,)
                     field = (key, val.dtype)
                 else:


### PR DESCRIPTION
Without this fix, the following error messages will appear when running `example/process.py`.
```
Traceback (most recent call last):
  File "example/process.py", line 60, in <module>
    main(sys.argv[1:])
  File "example/process.py", line 53, in main
    pynuml.process.hitgraph.process_file(out, inputfile,
  File "pynuml/process/hitgraph.py", line 259, in process_file
    out.save(data, name)
  File "pynuml/io/out.py", line 79, in save
    ctype = np.dtype(fields)
TypeError: Cannot interpret 'torch.int64' as a data type
```