### PR TITLE
Improve handling of scalar values in HDF5 compound data loading

### DIFF
--- a/pynuml/io/h5interface.py
+++ b/pynuml/io/h5interface.py
@@ -74,7 +74,7 @@ class H5Interface:
         for dataset in dataset_names:
             store, attr = dataset.split('/')
             if "_" in store: store = tuple(store.split("_"))
-            if attr in ['run','subrun','event','num_nodes']: # scalar
+            if group[dataset].size == 1: # scalar
                 data[store][attr] = torch.as_tensor(group[dataset][()])
             elif group[dataset].ndim == 0:
                 # other zero-dimensional size datasets

--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -161,6 +161,6 @@ class HitGraphProducer(ProcessorBase):
                 data[p].y_semantic = torch.tensor(plane_hits['semantic_label'].fillna(-1).values).long()
                 data[p].y_instance = torch.tensor(plane_hits['instance_label'].fillna(-1).values).long()
             if self.event_labeller:
-                data['evt'].y = self.event_labeller(evt['event_table'])
+                data['evt'].y = torch.tensor(self.event_labeller(evt['event_table'])).long()
 
         return evt.name, data


### PR DESCRIPTION
this PR fixes a bug that occurs when loading event truth labels from the heterogeneous graph compound data object. the previous implementation manually defined the names of graph attributes that corresponded to scalar values:

https://github.com/vhewes/pynuml/blob/09cad6d0ae01f3094139bcec6e218e6cbc9d56ca/pynuml/io/h5interface.py#L77-L78

since the event truth is a tensor containing a single value, it counts as a scalar value – but since it wasn't present in this list, it was erroneously being read as an empty multidimensional tensor.

the new implementation simply queries the size of the dataset to check whether it's a scalar value:

https://github.com/vhewes/pynuml/blob/1a4530b54f0ae31ef36fdfa6e624b56d31cd9aa9/pynuml/io/h5interface.py#L77-L78

which should be much more flexible and robust. the only potential issues this could cause in future are in the case of multidimensional tensors with a size of 1 in all dimensions, which would be loaded as single-dimensional tensors. i don't anticipate encountering this edge case any time soon, and if that changes then we can revisit this implementation then.

also contained is a minor tweak to the event labels themselves, which are explicitly converted to a torch tensor of longs before being saved. it probably doesn't make a difference, but it's a good practice.