### PR TITLE
Fix bug in compound data object

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'pynuml'
 copyright = '2023, v hewes'
 author = 'v hewes'
-release = '0.1.1'
+release = '23.6.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pynuml/__init__.py
+++ b/pynuml/__init__.py
@@ -1,6 +1,6 @@
 '''Standardised ML input processing for particle physics'''
 
-__version__ = '23.6.0'
+__version__ = '23.6.1'
 
 from . import io
 from . import labels

--- a/pynuml/io/h5interface.py
+++ b/pynuml/io/h5interface.py
@@ -72,10 +72,11 @@ class H5Interface:
         for dataset in group.dtype.names:
             store, attr = dataset.split('/')
             if "_" in store: store = tuple(store.split("_"))
-            if group[dataset].size == 0 and attr == 'edge_index':
-                data[store][attr] = torch.LongTensor([[],[]])
-            elif group[dataset].ndim == 0: # scalar
-                data[store][attr] = torch.as_tensor(group[dataset][()])
+            if group[dataset].ndim == 0:
+                if attr == 'edge_index': # empty edge tensor
+                    data[store][attr] = torch.LongTensor([[],[]])
+                else: # scalar
+                    data[store][attr] = torch.as_tensor(group[dataset][()])
             else: # multi-dimension array
                 data[store][attr] = torch.as_tensor(group[dataset][:])
         return data

--- a/pynuml/io/h5interface.py
+++ b/pynuml/io/h5interface.py
@@ -74,11 +74,12 @@ class H5Interface:
         for dataset in dataset_names:
             store, attr = dataset.split('/')
             if "_" in store: store = tuple(store.split("_"))
-            if group[dataset].size == 1: # scalar
-                data[store][attr] = torch.as_tensor(group[dataset][()])
-            elif group[dataset].ndim == 0:
-                # other zero-dimensional size datasets
-                data[store][attr] = torch.LongTensor([[],[]])
+            if group[dataset].ndim == 0:
+                if group[dataset].size == 1: # scalar
+                   data[store][attr] = torch.as_tensor(group[dataset][()])
+                else:
+                    # other zero-dimensional size datasets
+                    data[store][attr] = torch.LongTensor([[],[]])
             else: # multi-dimension array
                 data[store][attr] = torch.as_tensor(group[dataset][:])
         return data

--- a/pynuml/io/h5interface.py
+++ b/pynuml/io/h5interface.py
@@ -69,17 +69,13 @@ class H5Interface:
         data = HeteroData()
         # Read the whole dataset idx, dataset name is self.groups[idx]
         group = self.f[f'dataset/{name}'][()]
-        dataset_names = group.dtype.names
-
-        for dataset in dataset_names:
+        for dataset in group.dtype.names:
             store, attr = dataset.split('/')
             if "_" in store: store = tuple(store.split("_"))
-            if group[dataset].ndim == 0:
-                if group[dataset].size == 1: # scalar
-                   data[store][attr] = torch.as_tensor(group[dataset][()])
-                else:
-                    # other zero-dimensional size datasets
-                    data[store][attr] = torch.LongTensor([[],[]])
+            if group[dataset].size == 0 and attr == 'edge_index':
+                data[store][attr] = torch.LongTensor([[],[]])
+            elif group[dataset].ndim == 0: # scalar
+                data[store][attr] = torch.as_tensor(group[dataset][()])
             else: # multi-dimension array
                 data[store][attr] = torch.as_tensor(group[dataset][:])
         return data


### PR DESCRIPTION
this PR fixes an issue with handling scalar values and empty tensors in `H5Interface`. there was a previous PR to fix this issue that didn't work as intended, but this PR has been tested and appears to fix the issue. essentially, it's difficult to disambiguate between empty tensors and scalar values when loading tensors from the graph compound data object, and writing logic to do so is non-trivial.

the previous logic utilised a list of special keys corresponding to scalar values, and would load those as scalars; anything else would be loaded as an empty edge index tensor. however, this was problematic for two reasons:
- adding any new scalar values (such as an event truth label, which is how this issue was encountered) will cause problems if the corresponding keys weren't added to `H5Interface`'s list
- the logic to instantiate an empty tensor assumed it was a graph edge index tensor, which may not always be true

this PR implements a simple short-term fix: any empty datasets with the `edge_index` attribute names will be loaded as an empty edge index tensor, while anything else is loaded as a scalar. this implementation is not robust against any empty tensors that are not an edge index store, but the previous implementation wasn't either, so this should strictly be an improvement. i have ideas for how to implement an even more robust and flexible scheme going forward, but that isn't critical path so i'll open an issue to make that improvement sometime down the road.