### PR TITLE
add vertex labels to graph object

### DIFF
--- a/pynuml/labels/flavor.py
+++ b/pynuml/labels/flavor.py
@@ -33,8 +33,7 @@ class FlavorLabels:
     def nc(self):
         return self.index('nc')
 
-    def __call__(self, events: pd.DataFrame):
-        event = events.squeeze()
+    def __call__(self, event: pd.Series):
         if not event.is_cc:
             return self.nc
         pdg = abs(event.nu_pdg)

--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -160,7 +160,9 @@ class HitGraphProducer(ProcessorBase):
             if self.semantic_labeller:
                 data[p].y_semantic = torch.tensor(plane_hits['semantic_label'].fillna(-1).values).long()
                 data[p].y_instance = torch.tensor(plane_hits['instance_label'].fillna(-1).values).long()
-            if self.event_labeller:
-                data['evt'].y = torch.tensor(self.event_labeller(evt['event_table'])).long()
+
+        # event label
+        if self.event_labeller:
+            data['evt'].y = torch.tensor(self.event_labeller(evt['event_table'])).long()
 
         return evt.name, data

--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -171,7 +171,8 @@ class HitGraphProducer(ProcessorBase):
                 data[p].y_semantic = torch.tensor(plane_hits['semantic_label'].fillna(-1).values).long()
                 data[p].y_instance = torch.tensor(plane_hits['instance_label'].fillna(-1).values).long()
             if self.label_vertex:
-                data[p].y_vtx = torch.tensor([ event[f'nu_vtx_wire_pos_{i}'], event.nu_vtx_wire_time ]).float()
+                vtx_2d = torch.tensor([ event[f'nu_vtx_wire_pos_{i}'], event.nu_vtx_wire_time ]).float()
+                data[p].y_vtx = vtx_2d * self.pos_norm[None,:]
 
         # event label
         if self.event_labeller:

--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -50,7 +50,7 @@ class HitGraphProducer(ProcessorBase):
         if self.event_labeller:
             groups['event_table'] = ['is_cc', 'nu_pdg']
         if self.label_vertex:
-            keys = ['nu_vtx_x','nu_vtx_y','nu_vtx_z','nu_vtx_wire_pos_0','nu_vtx_wire_pos_1','nu_vtx_wire_pos_2','nu_vtx_wire_time']
+            keys = ['nu_vtx','nu_vtx_wire_pos','nu_vtx_wire_time']
             if 'event_table' in groups:
                 groups['event_table'].extend(keys)
             else:

--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -63,6 +63,8 @@ class HitGraphProducer(ProcessorBase):
         event_id = evt.event_id
         name = f'r{event_id[0]}_sr{event_id[1]}_evt{event_id[2]}'
 
+        event = evt['event_table'].squeeze()
+
         hits = evt['hit_table']
         spacepoints = evt['spacepoint_table'].reset_index(drop=True)
 
@@ -163,6 +165,6 @@ class HitGraphProducer(ProcessorBase):
 
         # event label
         if self.event_labeller:
-            data['evt'].y = torch.tensor(self.event_labeller(evt['event_table'])).long()
+            data['evt'].y = torch.tensor(self.event_labeller(event)).long()
 
         return evt.name, data

--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -130,9 +130,9 @@ class HitGraphProducer(ProcessorBase):
         data = pyg.data.HeteroData()
 
         # event metadata
-        data['metadata'].run = event_id[0]
-        data['metadata'].subrun = event_id[1]
-        data['metadata'].event = event_id[2]
+        data.run = event_id[0]
+        data.subrun = event_id[1]
+        data.event = event_id[2]
 
         # spacepoint nodes
         data['sp'].num_nodes = spacepoints.shape[0]
@@ -175,11 +175,11 @@ class HitGraphProducer(ProcessorBase):
 
         # event label
         if self.event_labeller:
-            data['evt'].y = torch.tensor(self.event_labeller(event)).long()
+            data.y_evt = torch.tensor(self.event_labeller(event)).long()
 
         # 3D vertex truth
         if self.label_vertex:
-            vtx_3d = [ event.nu_vtx_x, event.nu_vtx_y, event,nu_vtx_z ]
-            data['evt'].y_vtx = torch.tensor(vtx_3d).float()
+            vtx_3d = [ event.nu_vtx_x, event.nu_vtx_y, event.nu_vtx_z ]
+            data.y_vtx = torch.tensor(vtx_3d).float()
 
         return evt.name, data

--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -130,9 +130,9 @@ class HitGraphProducer(ProcessorBase):
         data = pyg.data.HeteroData()
 
         # event metadata
-        data.run = event_id[0]
-        data.subrun = event_id[1]
-        data.event = event_id[2]
+        data['metadata'].run = event_id[0]
+        data['metadata'].subrun = event_id[1]
+        data['metadata'].event = event_id[2]
 
         # spacepoint nodes
         data['sp'].num_nodes = spacepoints.shape[0]
@@ -176,11 +176,11 @@ class HitGraphProducer(ProcessorBase):
 
         # event label
         if self.event_labeller:
-            data.y_evt = torch.tensor(self.event_labeller(event)).long()
+            data['evt'].y = torch.tensor(self.event_labeller(event)).long()
 
         # 3D vertex truth
         if self.label_vertex:
             vtx_3d = [ event.nu_vtx_x, event.nu_vtx_y, event.nu_vtx_z ]
-            data.y_vtx = torch.tensor(vtx_3d).float()
+            data['evt'].y_vtx = torch.tensor(vtx_3d).float()
 
         return evt.name, data


### PR DESCRIPTION
this PR adds 2D and 3D event vertex position ground truth labels to graph processing, which enables the development of vertex regression tasks. the implementation is pretty inflexible for now, and will only work with MicroBooNE open data release files for the time being, but this should pave the way for future development on the HDF5-making side that will enable more widespread use.

this functionality is disabled by default, and must be manually enabled, so applications other than the uboone open data release should be unaffected.

also included is a *very* minor fix to event label processing: the event labelling was previously included inside the loop over detector planes, meaning it was run multiple times, which is totally harmless but unnecessary. as part of this PR, the event labelling is now outside the event loop, meaning it only gets run once.