### PR TITLE
update graph plotting

### DIFF
--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -24,15 +24,15 @@ class GraphPlot:
             df = pd.DataFrame(plane['id'], columns=['id'])
             df['plane'] = p
             df[['wire','time']] = plane['pos']
-            df['y_f'] = plane['y_f']
-            mask = df.y_f.values
-            df.loc[mask, 'y_s'] = to_categorical(plane['y_s'])
-            df.loc[mask, 'y_i'] = plane['y_i'].numpy()
-            if 'x_s' in plane.keys():
-                df['x_s'] = to_categorical(plane['x_s'].argmax(dim=-1).detach())
-                df[self._classes] = plane['x_s'].detach()
-            if 'x_f' in plane.keys():
-                df['x_f'] = plane['x_f'].detach()
+            df['y_filter'] = plane['y_semantic'] != -1
+            mask = df.y_filter.values
+            df['y_semantic'] = to_categorical(plane['y_semantic'])
+            df['y_instance'] = plane['y_instance'].numpy()
+            if 'x_semantic' in plane.keys():
+                df['x_semantic'] = to_categorical(plane['x_semantic'].argmax(dim=-1).detach())
+                df[self._classes] = plane['x_semantic'].detach()
+            if 'x_filter' in plane.keys():
+                df['x_filter'] = plane['x_filter'].detach()
             dfs.append(df)
         return pd.concat(dfs)
 
@@ -60,15 +60,15 @@ class GraphPlot:
             if how == 'true':
                 opts = {
                     'title': 'True semantic labels',
-                    'labels': { 'y_s': 'Semantic label' },
-                    'color': 'y_s',
+                    'labels': { 'y_semantic': 'Semantic label' },
+                    'color': 'y_semantic',
                     'color_discrete_map': self._cmap
                 }
             elif how == 'pred':
                 opts = {
                     'title': 'Predicted semantic labels',
-                    'labels': { 'x_s': 'Semantic label' },
-                    'color': 'x_s',
+                    'labels': { 'x_semantic': 'Semantic label' },
+                    'color': 'x_semantic',
                     'color_discrete_map': self._cmap
                 }
             elif how in self._classes:
@@ -86,14 +86,14 @@ class GraphPlot:
             if how == 'true':
                 opts = {
                     'title': 'True instance labels',
-                    'labels': { 'y_i': 'Instance label' },
-                    'color': 'y_i'
+                    'labels': { 'y_instance': 'Instance label' },
+                    'color': 'y_instance'
                 }
             elif how == 'pred':
                 opts = {
                     'title': 'Predicted instance labels',
-                    'labels': { 'x_i': 'Instance label' },
-                    'color': 'x_i'
+                    'labels': { 'x_instance': 'Instance label' },
+                    'color': 'x_instance'
                 }
             else:
                 raise Exception('for instance labels, "how" must be one of "true" or "pred".')
@@ -103,15 +103,15 @@ class GraphPlot:
             if how == 'true':
                 opts = {
                     'title': 'True filter labels',
-                    'labels': { 'y_f': 'Filter label' },
-                    'color': 'y_f',
+                    'labels': { 'y_filter': 'Filter label' },
+                    'color': 'y_filter',
                     'color_continuous_scale': px.colors.sequential.Reds
                 }
             elif how == 'pred':
                 opts = {
                     'title': 'Predicted filter labels',
-                    'labels': { 'x_f': 'Filter label' },
-                    'color': 'x_f',
+                    'labels': { 'x_filter': 'Filter label' },
+                    'color': 'x_filter',
                     'color_continuous_scale': px.colors.sequential.Reds
                 }
             else:
@@ -123,10 +123,10 @@ class GraphPlot:
         if filter == 'none':
             df = self._df
         elif filter == 'true':
-            df = self._df[self._df.y_f.values]
+            df = self._df[self._df.y_filter.values]
             opts['title'] += ' (filtered by truth)'
         elif filter == 'pred':
-            df = self._df[self._df.x_f > 0.5]
+            df = self._df[self._df.x_filter > 0.5]
             opts['title'] += ' (filtered by prediction)'
         else:
             raise Exception('"filter" must be one of "none", "true" or "pred.')

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -1,13 +1,12 @@
-from typing import List
-
 import pandas as pd
 from torch_geometric.data import HeteroData
 import plotly.express as px
+from plotly.graph_objects import FigureWidget
 
 class GraphPlot:
     def __init__(self,
-                 planes: List[str],
-                 classes: List[str]):
+                 planes: list[str],
+                 classes: list[str]):
         self._planes = planes
         self._classes = classes
         self._labels = pd.CategoricalDtype(classes, ordered=True)
@@ -38,12 +37,9 @@ class GraphPlot:
 
     def plot(self,
              data: HeteroData,
-             name: str,
              target: str = 'hits',
              how: str = 'none',
-             filter: str = 'none',
-             write_png: bool = True,
-             write_html: bool = False):
+             filter: str = 'none') -> FigureWidget:
 
         if data is not self._data:
             self._data = data
@@ -136,7 +132,4 @@ class GraphPlot:
         fig.update_xaxes(matches=None)
         for a in fig.layout.annotations:
             a.text = a.text.replace('plane=', '')
-        if write_html:
-            fig.write_html(f'{name}.html')
-        if write_png:
-            fig.write_image(f'{name}.png')
+        return FigureWidget(fig)


### PR DESCRIPTION
this PR includes bug fixes and implementation changes in pynuml's graph plotting utility.

PR #39 included changes to the names of ground truth tensors in the graph object, and also changes to how the various truth tensors are stored. the `GraphPlot` utility was never updated to reflect these changes, which caused errors when it was run. this PR updates `GraphPlot` so that it's compatible with the new graph structure.

`GraphPlot` has also been modified conceptually. previously, its `plot` function would take in a data object, some plotting options, an output file stub and some options for output filetypes (ie. PNG, HTML). however, this turns out to be pretty inflexible for cases where the user wants to visualise the plot in a notebook environment instead of writing it to disk, so the implementation has been reimagined.

in this PR, the name and filetype options have been dropped from the `plot` function, and instead of saving images to disk, the function returns a plotly `FigureWidget` object representing the plotted graph. the user is then free to do whatever they want with this figure – they can visualise it in a notebook, or call `FigureWidget`'s inbuilt functions to save an image to disk directly.