### PR TITLE
add script for installing ph5concat

### DIFF
--- a/scripts/install_ph5concat_conda.sh
+++ b/scripts/install_ph5concat_conda.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+git clone https://github.com/NU-CUCIS/ph5concat
+cd ph5concat
+autoreconf -i
+./configure --prefix=$CONDA_PREFIX \
+            --with-mpi=$CONDA_PREFIX \
+            --with-hdf5=$CONDA_PREFIX \
+            CFLAGS="-O2 -DNDEBUG" \
+            CXXFLAGS="-O2 -DNDEBUG" \
+            LIBS="-ldl -lz" \
+            --enable-profiling
+make install
+cd ..
+rm -fr ph5concat


### PR DESCRIPTION
add a simple utility script that installs the merging and metadata sequencing binaries to a conda environment from the [ph5concat repository](https://github.com/NU-CUCIS/ph5concat).