### PR TITLE
add second dimension to 3D vertex truth

### DIFF
--- a/pynuml/process/hitgraph.py
+++ b/pynuml/process/hitgraph.py
@@ -180,7 +180,7 @@ class HitGraphProducer(ProcessorBase):
 
         # 3D vertex truth
         if self.label_vertex:
-            vtx_3d = [ event.nu_vtx_x, event.nu_vtx_y, event.nu_vtx_z ]
+            vtx_3d = [ [ event.nu_vtx_x, event.nu_vtx_y, event.nu_vtx_z ] ]
             data['evt'].y_vtx = torch.tensor(vtx_3d).float()
 
         return evt.name, data


### PR DESCRIPTION
previously, the truth label tensor for the 3D vertex coordinates was a single-dimension tensor with size 3, which caused issues when batching together multiple graphs. this reshapes each event's true vertex to a two-dimensional tensor with size (1, 3), so batching N graphs together produces a tensor with size (N, 3), which is what we want.