### PR TITLE
label charged tau as HIP

### DIFF
--- a/pynuml/labels/standard.py
+++ b/pynuml/labels/standard.py
@@ -205,6 +205,10 @@ class StandardLabels:
                     else:
                         sl = self.diffuse
 
+                # call a charged tau highly ionising - should revisit this
+                if abs(part.type) == 15:
+                    sl = self.hadron
+
                 # check to make sure particle was assigned
                 if sl == -1:
                     unlabeled_particle(part, parent_type)


### PR DESCRIPTION
Tyler S came across an instance of a charged tau lepton showing up in an atmospheric event, so i'm adding it to the labelling scheme here. for now i'm calling it HIP, but we should probably revisit that down the road