### PR TITLE
Update graph plotting utilities

### DIFF
--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -9,14 +9,15 @@ class GraphPlot:
                  classes: list[str]):
         self._planes = planes
         self._classes = classes
-        self._labels = pd.CategoricalDtype(classes, ordered=True)
+        self._labels = pd.CategoricalDtype(['background']+classes, ordered=True)
         self._cmap = { c: px.colors.qualitative.Plotly[i] for i, c in enumerate(classes) }
+        self._cmap['background'] = 'lightgrey'
         self._data = None
         self._df = None
 
     def to_dataframe(self, data: HeteroData):
         def to_categorical(arr):
-            return pd.Categorical.from_codes(codes=arr, dtype=self._labels)
+            return pd.Categorical.from_codes(codes=arr+1, dtype=self._labels)
         if isinstance(data, Batch):
             raise Exception('to_dataframe does not support batches!')
         dfs = []

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -2,6 +2,7 @@ import pandas as pd
 from torch_geometric.data import Batch, HeteroData
 import plotly.express as px
 from plotly.graph_objects import FigureWidget
+import warnings
 
 class GraphPlot:
     def __init__(self,
@@ -14,6 +15,11 @@ class GraphPlot:
         self._cmap = { c: px.colors.qualitative.Plotly[i] for i, c in enumerate(classes) }
         self._cmap['background'] = 'lightgrey'
         self.filter_threshold = filter_threshold
+
+        # temporarily silence this pandas warning triggered by plotly,
+        # which we don't have any power to fix but will presumably
+        # be fixed on their end at some point
+        warnings.filterwarnings("ignore", ".*The default of observed=False is deprecated and will be changed to True in a future version of pandas.*")
 
     def to_dataframe(self, data: HeteroData):
         def to_categorical(arr):

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -6,7 +6,7 @@ from plotly.graph_objects import FigureWidget
 class GraphPlot:
     def __init__(self,
                  planes: list[str],
-                 classes: list[str]
+                 classes: list[str],
                  filter_threshold: float = 0.5):
         self._planes = planes
         self._classes = classes

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -12,8 +12,6 @@ class GraphPlot:
         self._labels = pd.CategoricalDtype(['background']+classes, ordered=True)
         self._cmap = { c: px.colors.qualitative.Plotly[i] for i, c in enumerate(classes) }
         self._cmap['background'] = 'lightgrey'
-        self._data = None
-        self._df = None
 
     def to_dataframe(self, data: HeteroData):
         def to_categorical(arr):
@@ -51,9 +49,7 @@ class GraphPlot:
              width: int = None,
              height: int = None) -> FigureWidget:
 
-        if data is not self._data:
-            self._data = data
-            self._df = self.to_dataframe(data)
+        df = self.to_dataframe(data)
 
         # no colour
         if target == 'hits':
@@ -127,12 +123,15 @@ class GraphPlot:
             raise Exception('"target" must be one of "hits", "semantic", "instance" or "filter".')
 
         if filter == 'none':
-            df = self._df
+            # don't do any filtering
+            pass
         elif filter == 'true':
-            df = self._df[self._df.y_filter.values]
+            # remove true background hits
+            df = df[df.y_filter.values]
             opts['title'] += ' (filtered by truth)'
         elif filter == 'pred':
-            df = self._df[self._df.x_filter > 0.5]
+            # remove predicted background hits
+            df = df[df.x_filter > 0.5]
             opts['title'] += ' (filtered by prediction)'
         else:
             raise Exception('"filter" must be one of "none", "true" or "pred.')

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -110,7 +110,7 @@ class GraphPlot:
                     'title': 'True filter labels',
                     'labels': { 'y_filter': 'Filter label' },
                     'color': 'y_filter',
-                    'color_continuous_scale': px.colors.sequential.Reds
+                    'color_discrete_map': { 0: 'coral', 1: 'mediumseagreen' },
                 }
             elif how == 'pred':
                 opts = {

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -6,12 +6,14 @@ from plotly.graph_objects import FigureWidget
 class GraphPlot:
     def __init__(self,
                  planes: list[str],
-                 classes: list[str]):
+                 classes: list[str]
+                 filter_threshold: float = 0.5):
         self._planes = planes
         self._classes = classes
         self._labels = pd.CategoricalDtype(['background']+classes, ordered=True)
         self._cmap = { c: px.colors.qualitative.Plotly[i] for i, c in enumerate(classes) }
         self._cmap['background'] = 'lightgrey'
+        self.filter_threshold = filter_threshold
 
     def to_dataframe(self, data: HeteroData):
         def to_categorical(arr):
@@ -131,7 +133,7 @@ class GraphPlot:
             opts['title'] += ' (filtered by truth)'
         elif filter == 'pred':
             # remove predicted background hits
-            df = df[df.x_filter > 0.5]
+            df = df[df.x_filter > self.filter_threshold]
             opts['title'] += ' (filtered by prediction)'
         else:
             raise Exception('"filter" must be one of "none", "true" or "pred.')

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -56,7 +56,7 @@ class GraphPlot:
         # no colour
         if target == 'hits':
             opts = {
-                'title': 'Graph hits'
+                'title': 'Graph hits',
             }
 
         # semantic labels
@@ -66,21 +66,21 @@ class GraphPlot:
                     'title': 'True semantic labels',
                     'labels': { 'y_semantic': 'Semantic label' },
                     'color': 'y_semantic',
-                    'color_discrete_map': self._cmap
+                    'color_discrete_map': self._cmap,
                 }
             elif how == 'pred':
                 opts = {
                     'title': 'Predicted semantic labels',
                     'labels': { 'x_semantic': 'Semantic label' },
                     'color': 'x_semantic',
-                    'color_discrete_map': self._cmap
+                    'color_discrete_map': self._cmap,
                 }
             elif how in self._classes:
                 opts = {
                     'title': f'Predicted semantic label strength for {how} class',
                     'labels': { how: f'{how} probability' },
                     'color': how,
-                    'color_continuous_scale': px.colors.sequential.Reds
+                    'color_continuous_scale': px.colors.sequential.Reds,
                 }
             else:
                 raise Exception('for semantic labels, "how" must be one of "true", "pred" or the name of a class.')
@@ -91,13 +91,13 @@ class GraphPlot:
                 opts = {
                     'title': 'True instance labels',
                     'labels': { 'y_instance': 'Instance label' },
-                    'color': 'y_instance'
+                    'color': 'y_instance',
                 }
             elif how == 'pred':
                 opts = {
                     'title': 'Predicted instance labels',
                     'labels': { 'x_instance': 'Instance label' },
-                    'color': 'x_instance'
+                    'color': 'x_instance',
                 }
             else:
                 raise Exception('for instance labels, "how" must be one of "true" or "pred".')
@@ -116,7 +116,7 @@ class GraphPlot:
                     'title': 'Predicted filter labels',
                     'labels': { 'x_filter': 'Filter label' },
                     'color': 'x_filter',
-                    'color_continuous_scale': px.colors.sequential.Reds
+                    'color_continuous_scale': px.colors.sequential.Reds,
                 }
             else:
                 raise Exception('for filter labels, "how" must be one of "true" or "pred".')

--- a/pynuml/plot/graph.py
+++ b/pynuml/plot/graph.py
@@ -53,7 +53,7 @@ class GraphPlot:
              data: HeteroData,
              target: str = 'hits',
              how: str = 'none',
-             filter: str = 'none',
+             filter: str = 'show',
              width: int = None,
              height: int = None) -> FigureWidget:
 
@@ -133,6 +133,10 @@ class GraphPlot:
         if filter == 'none':
             # don't do any filtering
             pass
+        elif filter == 'show':
+            # show hits predicted to be background in grey
+            if target == 'semantic' and how == 'pred':
+                df.x_semantic[df.x_filter < self.filter_threshold] = 'background'
         elif filter == 'true':
             # remove true background hits
             df = df[df.y_filter.values]
@@ -142,7 +146,7 @@ class GraphPlot:
             df = df[df.x_filter > self.filter_threshold]
             opts['title'] += ' (filtered by prediction)'
         else:
-            raise Exception('"filter" must be one of "none", "true" or "pred.')
+            raise Exception('"filter" must be one of "none", "show", "true" or "pred".')
 
         fig = px.scatter(df, x='wire', y='time', facet_col='plane',
                          width=width, height=height, **opts)


### PR DESCRIPTION
a few tweaks to graph plotting:

## manually set colour scheme for plotting filter truth

previously, the code would just use plotly's default red and blue colours, but the mapping of those colours to signal and background were inconsistent. the code has been reworked to use coral for background and sea green for signal :)

## show background hits when plotting semantic labels

a couple of tweaks here:

### true semantic labels

since we have no true semantic labels for background hits, those graph nodes would just get removed from event displays entirely when plotting true semantic labels, regardless of what the user passed for the `filter` argument in the plotting function. i tweaked the code to add an extra `background` category for sematic labels, so those hits are now shown greyed out. if the user doesn't want them, they can simply pass `filter=true` to recover the old behaviour

### predicted semantic labels

the network generates a semantic prediction for every hit, regardless of whether it's signal or background. previously, the plotting tools would draw the predicted semantic labels for all hits by default, and remove them entirely if the user passed `filter=pred`. this means the user essentially has to choose between visualising the filter prediction or the semantic prediction.

this PR adds a new `filter=show` option, which is also set to the default behaviour. this option uses the visualisation of a greyed-out `background` category described above, and overrides the predicted semantic label of all hits predicted as background to this greyed out class. this allows the user to produce an event display that shows the effect of filtering and semantic labelling simultaneously. if the user wants to show the predicted semantic labels of predicted background hits instead, they can pass `filter=none` to disable this behaviour

## configurable filter threshold

previously, generating a mask to filter hits by predicted score hardcoded a probability threshold of 0.5. the `GraphPlot` class now accepts an argument `filter_threshold` that defaults to 0.5, but the user can override this value if they want to use a more or less aggressive threshold.

## remove dataframe caching

when generating a dataframe from the graph object, `GraphPlot` used to cache this dataframe in order to replot. however, regenerating the dataframe is already pretty fast, so caching isn't rly necessary, and it makes code development annoying – if you modify the `to_dataframe` function, the code will continue to use the cached dataframe and won't pick up on the change. this caching has been removed, so whenever you call `GraphPlot.plot`, the dataframe will be regenerated under the hood. this should make zero difference to the end user :)